### PR TITLE
Document Codex PR readiness permission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository Agent Instructions
+
+## Pull Request Readiness
+
+Codex is pre-approved to mark draft pull requests as ready for review in this
+repository when the requested work is complete, required checks and review-app
+verification are passing or any non-blocking skip is documented, and there are
+no known unresolved blocking review comments or user-requested changes.
+
+Codex does not need to ask again before running `gh pr ready` under those
+conditions. If required checks are failing, review-app verification is broken,
+or blocking feedback remains unresolved, leave the pull request as draft and
+report the blocker instead.


### PR DESCRIPTION
Adds a repo-local `AGENTS.md` instruction so future Codex sessions may mark
draft PRs ready once the work is complete and checks/review-app verification
are clean.

This is a documentation-only agent instruction update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only agent policy with no runtime, security, or application code changes.
> 
> **Overview**
> Adds a new **`AGENTS.md`** with repo-local instructions for Codex on **pull request readiness**.
> 
> Codex may run **`gh pr ready`** without asking again when the requested work is done, required checks and review-app verification pass (or non-blocking skips are documented), and there are no unresolved blocking review comments or user-requested changes. If checks fail, review-app verification is broken, or blocking feedback remains, the PR stays draft and Codex should report the blocker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5af5769fba599c825a67f494a76f87f91093d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->